### PR TITLE
Feature/token send

### DIFF
--- a/templates/registration/verify_token.html
+++ b/templates/registration/verify_token.html
@@ -9,14 +9,6 @@
     <h2 class="text-3xl font-extrabold tracking-tight text-ink">Verify your login</h2>
     <p class="mt-3 text-sm leading-7 text-stone-500">Use the verification token sent to your email address to finish signing in and unlock your dashboard.</p>
 
-    {% if development_token %}
-    <div class="mt-5 rounded-2xl bg-sky-50 px-4 py-4 text-sm text-sky-900 ring-1 ring-sky-100">
-        <p class="font-semibold">Development token</p>
-        <p class="mt-1">Use this code while running locally.</p>
-        <p class="mt-3 font-mono text-2xl font-extrabold tracking-[0.3em]">{{ development_token }}</p>
-    </div>
-    {% endif %}
-
     <form method="post" class="mt-6 space-y-5">
         {% csrf_token %}
         {% for field in form %}

--- a/users/auth/views.py
+++ b/users/auth/views.py
@@ -9,7 +9,7 @@ from django.urls import reverse
 
 from .authentication_forms import SubscriptionAuthenticationForm
 from .forms import LoginTokenVerificationForm, ResendTokenForm, SignupForm
-from .token_service import clear_email_token, get_email_token, issue_email_token, verify_email_token
+from .token_service import clear_email_token, issue_email_token, verify_email_token
 
 
 User = get_user_model()
@@ -104,9 +104,6 @@ def verify_token_view(request):
         {
             "form": form,
             "resend_form": resend_form,
-            "development_token": (
-                get_email_token(request.user.email) if settings.SHOW_LOGIN_TOKEN_IN_UI else None
-            ),
         },
     )
 
@@ -127,9 +124,6 @@ def resend_token_view(request):
         {
             "form": LoginTokenVerificationForm(),
             "resend_form": ResendTokenForm(),
-            "development_token": (
-                get_email_token(request.user.email) if settings.SHOW_LOGIN_TOKEN_IN_UI else None
-            ),
         },
     )
 

--- a/users/auth/views.py
+++ b/users/auth/views.py
@@ -19,15 +19,13 @@ LEGACY_REACTIVATION_SESSION_KEY = "legacy_reactivation_user_id"
 
 def send_verification_token_email(user):
     token = issue_email_token(user.email)
-    if settings.SHOW_LOGIN_TOKEN_IN_UI:
-        return token
     send_mail(
         "Your Subscription Intelligence login token",
         (
             "Use this verification token to complete sign in: "
             f"{token}\n\nThis token expires in 10 minutes."
         ),
-        "noreply@subscriptionintelligence.com",
+        settings.DEFAULT_FROM_EMAIL,
         [user.email],
         fail_silently=False,
     )

--- a/users/tests/test_frontend_integration.py
+++ b/users/tests/test_frontend_integration.py
@@ -95,6 +95,7 @@ class FrontendIntegrationTest(TestCase):
         self.assertContains(response, "Verify your login")
         self.assertContains(response, 'name="token"', html=False)
         self.assertContains(response, "Resend token")
+        self.assertNotContains(response, "Development token")
 
     def test_verify_token_with_valid_code_activates_user(self):
         user = User.objects.create_user(

--- a/users/tests/test_user_registration.py
+++ b/users/tests/test_user_registration.py
@@ -1,4 +1,5 @@
 from django.test import TestCase
+from django.test.utils import override_settings
 from django.contrib.auth import get_user_model
 from django.urls import reverse
 from django.core import mail
@@ -74,3 +75,13 @@ class RegistrationTest(TestCase):
         self.assertRedirects(response, self.verify_url)
         self.assertEqual(len(mail.outbox), 2)
         self.assertIn('login token', mail.outbox[-1].subject.lower())
+
+    @override_settings(SHOW_LOGIN_TOKEN_IN_UI=True)
+    def test_login_still_sends_email_when_development_token_is_visible(self):
+        self.client.post(self.signup_url, self.user_data)
+        user = User.objects.get(email='tester@gmail.com')
+
+        response = self.client.post(self.login_url, {'username': user.username, 'password': 'Complex123!'})
+
+        self.assertRedirects(response, self.verify_url)
+        self.assertEqual(len(mail.outbox), 1)


### PR DESCRIPTION
## Summary
This branch fixes the login token flow so verification codes are actually delivered to the user’s email and removes the temporary development token fallback from the UI.

## What Changed
- Fixed the login verification flow so `send_verification_token_email()` always sends the 6-digit token by email instead of skipping delivery in development mode.
- Switched the sender address to `DEFAULT_FROM_EMAIL` so the app uses the configured mail settings from `.env`.
- Removed the “Development token” box from the verify-token page.
- Cleaned up the unused view context and token lookup logic tied to that development-only UI.
- Added/updated tests to cover:
  - email sending during login
  - email sending even when development-oriented settings are enabled
  - absence of the development token box in the verification UI

## Why
We need the token to reliably reach the user’s inbox, because the downstream subscription discovery flow depends on access to the user’s actual email account. Keeping a visible development token on the page undermined the real-world flow and masked email delivery issues.

## Testing
```bash
pytest users/tests/test_frontend_integration.py users/tests/test_user_registration.py
