### PR TITLE
Feature/forget username or password

### DIFF
--- a/templates/registration/forgot_password.html
+++ b/templates/registration/forgot_password.html
@@ -1,0 +1,30 @@
+{% extends "registration/auth_base.html" %}
+
+{% block title %}Recover Password | Subscription Intelligence{% endblock %}
+{% block hero_title %}Reset your account access{% endblock %}
+{% block hero_copy %}Use the email address on your account and we'll send a temporary password that meets the current password rules.{% endblock %}
+
+{% block panel_content %}
+<div class="rounded-3xl border border-black/5 bg-white p-7 shadow-sm">
+    <h2 class="text-3xl font-extrabold tracking-tight text-ink">Forgot password</h2>
+    <p class="mt-3 text-sm leading-7 text-stone-500">Enter the email address associated with your account and we'll email a temporary password. Your old password will stop working.</p>
+
+    <form method="post" class="mt-6 space-y-5" novalidate hx-boost="true">
+        {% csrf_token %}
+        <div>
+            <label class="mb-2 block text-sm font-bold text-ink" for="{{ form.email.id_for_label }}">Account email</label>
+            {{ form.email }}
+            {% if form.email.errors %}
+            <ul class="mt-2 list-disc pl-5 text-sm text-rose-700">
+                {% for error in form.email.errors %}
+                <li>{{ error }}</li>
+                {% endfor %}
+            </ul>
+            {% endif %}
+        </div>
+        <button class="inline-flex w-full items-center justify-center rounded-2xl bg-gradient-to-r from-pine to-pineDeep px-5 py-3.5 text-sm font-extrabold text-white shadow-lg shadow-pine/20 transition hover:-translate-y-0.5" type="submit">Send temporary password</button>
+    </form>
+
+    <p class="mt-5 text-sm text-stone-500">Remembered it? <a class="font-bold text-pine hover:text-pineDeep" href="{% url 'accounts:login' %}">Return to sign in</a></p>
+</div>
+{% endblock %}

--- a/templates/registration/forgot_username.html
+++ b/templates/registration/forgot_username.html
@@ -1,0 +1,30 @@
+{% extends "registration/auth_base.html" %}
+
+{% block title %}Recover Username | Subscription Intelligence{% endblock %}
+{% block hero_title %}Recover your account access{% endblock %}
+{% block hero_copy %}Use the email address on your account and we'll send back the username connected to it.{% endblock %}
+
+{% block panel_content %}
+<div class="rounded-3xl border border-black/5 bg-white p-7 shadow-sm">
+    <h2 class="text-3xl font-extrabold tracking-tight text-ink">Forgot username</h2>
+    <p class="mt-3 text-sm leading-7 text-stone-500">Enter the email address associated with your account and we'll email your username.</p>
+
+    <form method="post" class="mt-6 space-y-5" novalidate hx-boost="true">
+        {% csrf_token %}
+        <div>
+            <label class="mb-2 block text-sm font-bold text-ink" for="{{ form.email.id_for_label }}">Account email</label>
+            {{ form.email }}
+            {% if form.email.errors %}
+            <ul class="mt-2 list-disc pl-5 text-sm text-rose-700">
+                {% for error in form.email.errors %}
+                <li>{{ error }}</li>
+                {% endfor %}
+            </ul>
+            {% endif %}
+        </div>
+        <button class="inline-flex w-full items-center justify-center rounded-2xl bg-gradient-to-r from-pine to-pineDeep px-5 py-3.5 text-sm font-extrabold text-white shadow-lg shadow-pine/20 transition hover:-translate-y-0.5" type="submit">Email my username</button>
+    </form>
+
+    <p class="mt-5 text-sm text-stone-500">Remembered it? <a class="font-bold text-pine hover:text-pineDeep" href="{% url 'accounts:login' %}">Return to sign in</a></p>
+</div>
+{% endblock %}

--- a/templates/registration/login.html
+++ b/templates/registration/login.html
@@ -54,6 +54,11 @@
         <button class="inline-flex w-full items-center justify-center rounded-2xl bg-gradient-to-r from-pine to-pineDeep px-5 py-3.5 text-sm font-extrabold text-white shadow-lg shadow-pine/20 transition hover:-translate-y-0.5" type="submit">Sign in</button>
     </form>
 
+    <div class="mt-5 flex flex-wrap gap-x-4 gap-y-2 text-sm">
+        <a class="font-bold text-pine hover:text-pineDeep" href="{% url 'accounts:forgot_username' %}">Forgot username?</a>
+        <a class="font-bold text-pine hover:text-pineDeep" href="{% url 'accounts:forgot_password' %}">Forgot password?</a>
+    </div>
+
     <p class="mt-5 text-sm text-stone-500">New here? <a class="font-bold text-pine hover:text-pineDeep" href="{% url 'accounts:signup' %}">Create your account</a></p>
 </div>
 {% endblock %}

--- a/users/auth/forms.py
+++ b/users/auth/forms.py
@@ -129,3 +129,20 @@ class LoginTokenVerificationForm(forms.Form):
 
 class ResendTokenForm(forms.Form):
     pass
+
+
+class AccountRecoveryForm(forms.Form):
+    email = forms.EmailField(label="Account email")
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        input_classes = (
+            "block w-full rounded-2xl border-black/10 bg-stone-50 px-4 py-3 "
+            "text-sm shadow-sm transition focus:border-pine focus:ring-pine"
+        )
+        self.fields["email"].widget.attrs.setdefault("class", input_classes)
+        self.fields["email"].widget.attrs.setdefault("placeholder", "Enter your account email")
+        self.fields["email"].widget.attrs["autocomplete"] = "email"
+
+    def clean_email(self):
+        return self.cleaned_data["email"].strip().lower()

--- a/users/auth/urls.py
+++ b/users/auth/urls.py
@@ -3,6 +3,8 @@ from .views import (
     SubscriptionLoginView,
     activate_view,
     cancel_token_verification_view,
+    forgot_password_view,
+    forgot_username_view,
     reactivate_legacy_account_view,
     resend_token_view,
     signup_view,
@@ -13,6 +15,8 @@ app_name = 'accounts'
 
 urlpatterns = [
     path('signup/', signup_view, name='signup'),
+    path('forgot-username/', forgot_username_view, name='forgot_username'),
+    path('forgot-password/', forgot_password_view, name='forgot_password'),
     path('verify-token/', verify_token_view, name='verify_token'),
     path('resend-token/', resend_token_view, name='resend_token'),
     path('cancel-verification/', cancel_token_verification_view, name='cancel_verification'),

--- a/users/auth/views.py
+++ b/users/auth/views.py
@@ -1,5 +1,9 @@
+import secrets
+import string
+
 from django.contrib import messages
 from django.contrib.auth import get_user_model, logout
+from django.contrib.auth import password_validation
 from django.contrib.auth.views import LoginView
 from django.conf import settings
 from django.core.mail import send_mail
@@ -8,7 +12,7 @@ from django.shortcuts import redirect, render
 from django.urls import reverse
 
 from .authentication_forms import SubscriptionAuthenticationForm
-from .forms import LoginTokenVerificationForm, ResendTokenForm, SignupForm
+from .forms import AccountRecoveryForm, LoginTokenVerificationForm, ResendTokenForm, SignupForm
 from .token_service import clear_email_token, issue_email_token, verify_email_token
 
 
@@ -30,6 +34,55 @@ def send_verification_token_email(user):
         fail_silently=False,
     )
     return token
+
+
+def _generate_temporary_password(user):
+    alphabet = string.ascii_letters + string.digits + "!@#$%^&*"
+    required_characters = [
+        secrets.choice(string.ascii_lowercase),
+        secrets.choice(string.ascii_uppercase),
+        secrets.choice(string.digits),
+        secrets.choice("!@#$%^&*"),
+    ]
+    for _ in range(40):
+        remaining = [secrets.choice(alphabet) for _ in range(12)]
+        characters = required_characters + remaining
+        secrets.SystemRandom().shuffle(characters)
+        password = "".join(characters)
+        try:
+            password_validation.validate_password(password, user)
+        except Exception:
+            continue
+        return password
+    raise RuntimeError("Unable to generate a compliant temporary password.")
+
+
+def send_username_recovery_email(user):
+    send_mail(
+        "Your Subscription Intelligence username",
+        (
+            "We received a request to recover the username for your Subscription Intelligence account.\n\n"
+            f"Your username is: {user.username}\n\n"
+            "If you did not request this, you can ignore this email."
+        ),
+        settings.DEFAULT_FROM_EMAIL,
+        [user.email],
+        fail_silently=False,
+    )
+
+
+def send_temporary_password_email(user, temporary_password):
+    send_mail(
+        "Your temporary Subscription Intelligence password",
+        (
+            "We received a request to reset the password for your Subscription Intelligence account.\n\n"
+            f"Your temporary password is: {temporary_password}\n\n"
+            "Use this temporary password the next time you sign in. Your old password will no longer work."
+        ),
+        settings.DEFAULT_FROM_EMAIL,
+        [user.email],
+        fail_silently=False,
+    )
 
 
 class SubscriptionLoginView(LoginView):
@@ -73,6 +126,49 @@ def signup_view(request):
             messages.success(request, "Your account has been created. Sign in to receive your verification token.")
             return redirect("accounts:login")
     return render(request, "registration/signup.html", {"form": form})
+
+
+def forgot_username_view(request):
+    form = AccountRecoveryForm(request.POST or None)
+    if request.method == "POST" and form.is_valid():
+        email = form.cleaned_data["email"]
+        user = User.objects.filter(email__iexact=email).first()
+        if user is None:
+            form.add_error("email", "No account is associated with this email address.")
+        else:
+            send_username_recovery_email(user)
+            messages.success(request, "Your username has been sent to the email address on the account.")
+            return redirect("accounts:login")
+    return render(
+        request,
+        "registration/forgot_username.html",
+        {
+            "form": form,
+        },
+    )
+
+
+def forgot_password_view(request):
+    form = AccountRecoveryForm(request.POST or None)
+    if request.method == "POST" and form.is_valid():
+        email = form.cleaned_data["email"]
+        user = User.objects.filter(email__iexact=email).first()
+        if user is None:
+            form.add_error("email", "No account is associated with this email address.")
+        else:
+            temporary_password = _generate_temporary_password(user)
+            user.set_password(temporary_password)
+            user.save(update_fields=["password"])
+            send_temporary_password_email(user, temporary_password)
+            messages.success(request, "A temporary password has been sent to the email address on the account.")
+            return redirect("accounts:login")
+    return render(
+        request,
+        "registration/forgot_password.html",
+        {
+            "form": form,
+        },
+    )
 
 
 def verify_token_view(request):

--- a/users/tests/test_frontend_integration.py
+++ b/users/tests/test_frontend_integration.py
@@ -14,6 +14,8 @@ class FrontendIntegrationTest(TestCase):
         self.login_url = reverse("accounts:login")
         self.verify_url = reverse("accounts:verify_token")
         self.resend_url = reverse("accounts:resend_token")
+        self.forgot_username_url = reverse("accounts:forgot_username")
+        self.forgot_password_url = reverse("accounts:forgot_password")
         self.dashboard_url = reverse("dashboard")
         self.valid_signup = {
             "first_name": "Taylor",
@@ -157,6 +159,25 @@ class FrontendIntegrationTest(TestCase):
         self.assertRedirects(response, self.verify_url)
         self.assertContains(response, "Enter the 6-digit token we sent to your email to finish signing in.")
         self.assertContains(response, "Verify your login")
+
+    def test_login_page_links_to_account_recovery(self):
+        response = self.client.get(self.login_url)
+
+        self.assertContains(response, "Forgot username?")
+        self.assertContains(response, self.forgot_username_url)
+        self.assertContains(response, "Forgot password?")
+        self.assertContains(response, self.forgot_password_url)
+
+    def test_recovery_pages_render(self):
+        username_response = self.client.get(self.forgot_username_url)
+        password_response = self.client.get(self.forgot_password_url)
+
+        self.assertContains(username_response, "Forgot username")
+        self.assertContains(username_response, 'name="email"', html=False)
+        self.assertContains(username_response, "Email my username")
+        self.assertContains(password_response, "Forgot password")
+        self.assertContains(password_response, 'name="email"', html=False)
+        self.assertContains(password_response, "Send temporary password")
 
     def test_login_invalid_credentials_message_states_case_sensitivity(self):
         user = User.objects.create_user(

--- a/users/tests/test_user_registration.py
+++ b/users/tests/test_user_registration.py
@@ -1,6 +1,7 @@
 from django.test import TestCase
 from django.test.utils import override_settings
 from django.contrib.auth import get_user_model
+from django.contrib.auth.password_validation import validate_password
 from django.urls import reverse
 from django.core import mail
 import re
@@ -13,6 +14,8 @@ class RegistrationTest(TestCase):
         self.verify_url = reverse('accounts:verify_token')
         self.resend_url = reverse('accounts:resend_token')
         self.login_url = reverse('accounts:login')
+        self.forgot_username_url = reverse('accounts:forgot_username')
+        self.forgot_password_url = reverse('accounts:forgot_password')
         self.user_data = {
             'first_name': 'Taylor',
             'last_name': 'Jordan',
@@ -85,3 +88,76 @@ class RegistrationTest(TestCase):
 
         self.assertRedirects(response, self.verify_url)
         self.assertEqual(len(mail.outbox), 1)
+
+    def test_forgot_username_emails_associated_username(self):
+        User.objects.create_user(
+            username='recoveruser',
+            email='recover@gmail.com',
+            password='Complex123!',
+            is_active=True,
+        )
+
+        response = self.client.post(
+            self.forgot_username_url,
+            {'email': 'RECOVER@gmail.com'},
+            follow=True,
+        )
+
+        self.assertRedirects(response, self.login_url)
+        self.assertContains(response, 'Your username has been sent')
+        self.assertEqual(len(mail.outbox), 1)
+        self.assertIn('username', mail.outbox[0].subject.lower())
+        self.assertIn('recoveruser', mail.outbox[0].body)
+        self.assertNotIn('Complex123!', mail.outbox[0].body)
+
+    def test_forgot_username_tells_user_when_email_has_no_account(self):
+        response = self.client.post(
+            self.forgot_username_url,
+            {'email': 'missing@gmail.com'},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'No account is associated with this email address.')
+        self.assertEqual(len(mail.outbox), 0)
+
+    def test_forgot_password_sends_temporary_password_and_replaces_old_password(self):
+        user = User.objects.create_user(
+            username='resetuser',
+            email='reset@gmail.com',
+            password='Complex123!',
+            is_active=True,
+        )
+
+        response = self.client.post(
+            self.forgot_password_url,
+            {'email': 'reset@gmail.com'},
+            follow=True,
+        )
+
+        self.assertRedirects(response, self.login_url)
+        self.assertContains(response, 'A temporary password has been sent')
+        self.assertEqual(len(mail.outbox), 1)
+        self.assertIn('temporary', mail.outbox[0].subject.lower())
+        self.assertNotIn('Complex123!', mail.outbox[0].body)
+
+        temporary_password = re.search(r'Your temporary password is: ([^\n]+)', mail.outbox[0].body).group(1)
+        validate_password(temporary_password, user)
+        user.refresh_from_db()
+        self.assertFalse(user.check_password('Complex123!'))
+        self.assertTrue(user.check_password(temporary_password))
+
+        login_response = self.client.post(
+            self.login_url,
+            {'username': user.username, 'password': temporary_password},
+        )
+        self.assertRedirects(login_response, self.verify_url)
+
+    def test_forgot_password_tells_user_when_email_has_no_account(self):
+        response = self.client.post(
+            self.forgot_password_url,
+            {'email': 'missing@gmail.com'},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'No account is associated with this email address.')
+        self.assertEqual(len(mail.outbox), 0)

--- a/users/tests/test_user_security.py
+++ b/users/tests/test_user_security.py
@@ -3,6 +3,9 @@ from django.contrib.auth import get_user_model
 from django.core.exceptions import ValidationError
 from django.contrib.auth.password_validation import validate_password
 
+from users.auth.forms import AccountRecoveryForm
+from users.auth.views import _generate_temporary_password
+
 User = get_user_model()
 
 class UserSecurityTest(TestCase):
@@ -43,3 +46,27 @@ class UserSecurityTest(TestCase):
         with self.assertRaises(ValidationError):
             # clean_fields is safer than full_clean when the object is incomplete
             user.clean_fields(exclude=['password', 'last_login'])
+
+    def test_account_recovery_form_normalizes_email(self):
+        form = AccountRecoveryForm(data={"email": "  RECOVERY@GMAIL.COM  "})
+
+        self.assertTrue(form.is_valid())
+        self.assertEqual(form.cleaned_data["email"], "recovery@gmail.com")
+
+    def test_account_recovery_form_rejects_invalid_email(self):
+        form = AccountRecoveryForm(data={"email": "not-an-email"})
+
+        self.assertFalse(form.is_valid())
+        self.assertIn("email", form.errors)
+
+    def test_temporary_password_generator_meets_password_requirements(self):
+        user = User(username="temporaryuser", email="temporary@gmail.com")
+
+        temporary_password = _generate_temporary_password(user)
+
+        validate_password(temporary_password, user)
+        self.assertGreaterEqual(len(temporary_password), 8)
+        self.assertRegex(temporary_password, r"[a-z]")
+        self.assertRegex(temporary_password, r"[A-Z]")
+        self.assertRegex(temporary_password, r"[0-9]")
+        self.assertRegex(temporary_password, r'[!@#$%^&*(),.?":{}|<>]')


### PR DESCRIPTION
## Summary

Adds account recovery for users who forget their username or password.

## Changes

- Added login page links for “Forgot username?” and “Forgot password?”
- Added username recovery flow by account email.
- Added password recovery flow that generates and emails a compliant temporary password.
- Replaces the old password immediately when a temporary password is issued.
- Shows a clear error when no account is associated with the submitted email.
- Added recovery templates and URL routes.
- Added unit and integration test coverage for recovery forms, email flows, temporary password behavior, and login with the temporary password.

## Testing

- `pytest users`
- `python manage.py check`
- `pytest`

## Notes

- Passwords are never emailed back to the user.
- Username/password change screens are intentionally left for a future feature.
