### PR TITLE
Bugfix/login recovery

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -145,3 +145,4 @@ EMAIL_SCAN_LOOKBACK_DAYS = env.int('EMAIL_SCAN_LOOKBACK_DAYS', default=180)
 EMAIL_SCAN_MAX_MESSAGES = env.int('EMAIL_SCAN_MAX_MESSAGES', default=200)
 SHOW_LOGIN_TOKEN_IN_UI = env.bool('SHOW_LOGIN_TOKEN_IN_UI', default=DEBUG and not RUNNING_TESTS)
 LOGIN_URL = '/accounts/login/'
+CSRF_FAILURE_VIEW = 'users.auth.views.csrf_failure_view'

--- a/templates/registration/login.html
+++ b/templates/registration/login.html
@@ -25,7 +25,7 @@
     </div>
     {% endif %}
 
-    <form method="post" class="mt-6 space-y-5" hx-boost="true">
+    <form method="post" class="mt-6 space-y-5">
         {% csrf_token %}
         <div>
             <label class="mb-2 block text-sm font-bold text-ink" for="{{ form.username.id_for_label }}">Username</label>

--- a/users/auth/views.py
+++ b/users/auth/views.py
@@ -1,5 +1,8 @@
 from django.contrib import messages
-from django.contrib.auth import get_user_model, logout
+import logging
+from smtplib import SMTPException
+
+from django.contrib.auth import get_user_model, login, logout
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.tokens import default_token_generator
 from django.contrib.auth.views import LoginView
@@ -12,6 +15,7 @@ from django.utils.encoding import force_str
 from django.utils.http import urlsafe_base64_decode, urlsafe_base64_encode
 from django.utils.encoding import force_bytes
 from django.contrib.sessions.models import Session
+from django.views.decorators.csrf import requires_csrf_token
 
 from .authentication_forms import SubscriptionAuthenticationForm
 from .forms import (
@@ -35,6 +39,7 @@ from .token_service import clear_email_token, issue_email_token, verify_email_to
 
 
 User = get_user_model()
+logger = logging.getLogger(__name__)
 LOGIN_TOKEN_VERIFIED_SESSION_KEY = "login_token_verified"
 LEGACY_REACTIVATION_SESSION_KEY = "legacy_reactivation_user_id"
 USERNAME_CHANGE_TOKEN_PURPOSE = "username-change"
@@ -44,6 +49,12 @@ RECOVERY_RATE_LIMIT = 5
 TOKEN_VERIFY_RATE_LIMIT = 5
 TOKEN_RESEND_RATE_LIMIT = 3
 RATE_LIMIT_WINDOW_SECONDS = 900
+
+
+@requires_csrf_token
+def csrf_failure_view(request, reason=""):
+    messages.error(request, "Your sign-in session expired. Please try again.")
+    return render(request, "registration/login.html", {"form": SubscriptionAuthenticationForm(request)})
 
 
 def _require_verified_session(request):
@@ -148,11 +159,21 @@ class SubscriptionLoginView(LoginView):
         return super().dispatch(request, *args, **kwargs)
 
     def form_valid(self, form):
-        response = super().form_valid(form)
+        user = form.get_user()
+        try:
+            send_verification_token_email(user)
+        except (OSError, SMTPException):
+            logger.exception("Failed to send login verification token.")
+            form.add_error(
+                None,
+                "We could not send your verification token. Check the email settings and try again.",
+            )
+            return self.render_to_response(self.get_context_data(form=form))
+
+        login(self.request, user)
         self.request.session.pop(LEGACY_REACTIVATION_SESSION_KEY, None)
         clear_attempts("login", form.cleaned_data.get("username", ""), get_client_ip(self.request))
         self.request.session[LOGIN_TOKEN_VERIFIED_SESSION_KEY] = False
-        send_verification_token_email(self.request.user)
         messages.success(self.request, "Enter the 6-digit token we sent to your email to finish signing in.")
         return redirect("accounts:verify_token")
 
@@ -457,9 +478,14 @@ def resend_token_view(request):
                 limit=TOKEN_RESEND_RATE_LIMIT,
                 window_seconds=RATE_LIMIT_WINDOW_SECONDS,
             )
-            send_verification_token_email(request.user)
-            request.session[LOGIN_TOKEN_VERIFIED_SESSION_KEY] = False
-            messages.success(request, "A new verification token has been sent.")
+            try:
+                send_verification_token_email(request.user)
+            except (OSError, SMTPException):
+                logger.exception("Failed to resend login verification token.")
+                messages.error(request, "We could not send a new verification token. Check the email settings and try again.")
+            else:
+                request.session[LOGIN_TOKEN_VERIFIED_SESSION_KEY] = False
+                messages.success(request, "A new verification token has been sent.")
         return redirect("accounts:verify_token")
 
     return render(

--- a/users/tests/test_frontend_integration.py
+++ b/users/tests/test_frontend_integration.py
@@ -1,8 +1,10 @@
 from django.contrib.auth import get_user_model
 from django.core.cache import cache
 from django.core import mail
-from django.test import TestCase
+from django.test import Client, TestCase
 from django.urls import reverse
+from smtplib import SMTPAuthenticationError
+from unittest.mock import patch
 import re
 
 
@@ -172,16 +174,82 @@ class FrontendIntegrationTest(TestCase):
         self.assertContains(response, "Enter the 6-digit token we sent to your email to finish signing in.")
         self.assertContains(response, "Verify your login")
 
+    def test_login_email_delivery_failure_returns_visible_error(self):
+        user = User.objects.create_user(
+            username="mailfail",
+            email="mailfail@gmail.com",
+            password="Complex123!",
+            is_active=True,
+        )
+
+        with patch(
+            "users.auth.views.send_verification_token_email",
+            side_effect=SMTPAuthenticationError(535, b"Bad credentials"),
+        ), patch("users.auth.views.logger.exception"):
+            response = self.client.post(
+                self.login_url,
+                {"username": user.username, "password": "Complex123!"},
+            )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "We could not send your verification token.")
+        self.assertNotIn("_auth_user_id", self.client.session)
+        self.assertEqual(len(mail.outbox), 0)
+
     def test_login_page_links_to_account_recovery(self):
         response = self.client.get(self.login_url)
 
         self.assertContains(response, 'data-password-toggle="id_password"', html=False)
         self.assertContains(response, 'aria-label="Show password"', html=False)
+        self.assertNotContains(response, 'hx-boost="true"', html=False)
         self.assertContains(response, "password_visibility.js")
         self.assertContains(response, "Forgot username?")
         self.assertContains(response, self.forgot_username_url)
         self.assertContains(response, "Forgot password?")
         self.assertContains(response, self.forgot_password_url)
+
+    def test_login_accepts_valid_csrf_token_when_csrf_checks_are_enforced(self):
+        user = User.objects.create_user(
+            username="csrfvalid",
+            email="csrfvalid@gmail.com",
+            password="Complex123!",
+            is_active=True,
+        )
+        csrf_client = Client(enforce_csrf_checks=True)
+        login_response = csrf_client.get(self.login_url)
+        token = re.search(
+            r'name="csrfmiddlewaretoken" value="([^"]+)"',
+            login_response.content.decode(),
+        ).group(1)
+
+        response = csrf_client.post(
+            self.login_url,
+            {
+                "username": user.username,
+                "password": "Complex123!",
+                "csrfmiddlewaretoken": token,
+            },
+        )
+
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response["Location"], self.verify_url)
+
+    def test_login_csrf_failure_returns_recoverable_login_page(self):
+        csrf_client = Client(enforce_csrf_checks=True)
+        csrf_client.get(self.login_url)
+
+        response = csrf_client.post(
+            self.login_url,
+            {
+                "username": "anyone",
+                "password": "Complex123!",
+                "csrfmiddlewaretoken": "a" * 64,
+            },
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Your sign-in session expired. Please try again.")
+        self.assertContains(response, "Welcome back")
 
     def test_recovery_pages_render(self):
         username_response = self.client.get(self.forgot_username_url)


### PR DESCRIPTION
# Fix Login Recovery Safeguards

## Summary
This PR hardens the login verification flow so users get recoverable, visible errors when sign-in token delivery or CSRF validation fails.

## Changes
- Sends the login verification email before creating the authenticated session.
- Shows a clear login-page error if verification token email delivery fails.
- Adds a custom CSRF failure view that returns the login page with a “session expired” message.
- Removes `hx-boost` from the login form to avoid CSRF/session handling issues during sign-in.
- Handles resend-token email delivery failures without breaking the verification page.
- Adds frontend integration coverage for:
  - email delivery failure during login
  - valid CSRF-protected login
  - CSRF failure recovery
  - login page recovery links and non-HTMX form behavior

## Testing
```bash
pytest users/tests/test_frontend_integration.py
