### PR TITLE
Refactor/account settings

### DIFF
--- a/subscriptions/migrations/0010_scan_preferences_rules.py
+++ b/subscriptions/migrations/0010_scan_preferences_rules.py
@@ -1,0 +1,20 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("subscriptions", "0009_emailscanpreference"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="emailscanpreference",
+            name="email_selection_rules",
+            field=models.TextField(blank=True, default=""),
+        ),
+        migrations.AddField(
+            model_name="emailscanpreference",
+            name="scan_intervals",
+            field=models.JSONField(blank=True, default=list),
+        ),
+    ]

--- a/subscriptions/models.py
+++ b/subscriptions/models.py
@@ -142,6 +142,8 @@ class EmailScanPreference(models.Model):
     scan_scope = models.CharField(max_length=30, choices=SCOPE_CHOICES, default=SCOPE_RECEIPTS_ONLY)
     retention_period_days = models.PositiveIntegerField(default=180)
     automatic_scans = models.BooleanField(default=False)
+    scan_intervals = models.JSONField(default=list, blank=True)
+    email_selection_rules = models.TextField(blank=True, default="")
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)
 

--- a/subscriptions/services.py
+++ b/subscriptions/services.py
@@ -23,6 +23,7 @@ from django.utils import timezone
 
 from .models import (
     EmailConnection,
+    EmailScanPreference,
     EmailScanRun,
     EmailSubscriptionLead,
     Subscription,
@@ -511,6 +512,17 @@ def _scan_gmail_connection(user, email_connection_id):
     if connection is None:
         raise InboxScanError("Email connection was not found for this account.")
     if connection.status != EmailConnection.STATUS_ACTIVE:
+        EmailScanRun.objects.create(
+            user=user,
+            email_connection=connection,
+            provider="gmail_permission_revoked",
+            mailbox=connection.email_address,
+            status=EmailScanRun.STATUS_FAILED,
+            error_details={
+                "errors": ["Reconnect Gmail to scan this mailbox."],
+                "warning_state": "gmail_permission_revoked",
+            },
+        )
         raise InboxScanError("Reconnect Gmail to scan this mailbox.")
     if connection.token_expires_at and connection.token_expires_at <= timezone.now():
         refresh_gmail_access_token(connection)
@@ -523,7 +535,13 @@ def _scan_gmail_connection(user, email_connection_id):
         mailbox=connection.email_address,
         status=EmailScanRun.STATUS_SUCCEEDED,
     )
-    query = f"newer_than:{lookback_days}d (receipt OR invoice OR subscription OR billing OR renewal OR charged)"
+    scan_preferences = EmailScanPreference.objects.filter(user=user).first()
+    query_terms = "receipt OR invoice OR subscription OR billing OR renewal OR charged"
+    if scan_preferences and scan_preferences.scan_scope == EmailScanPreference.SCOPE_RECEIPTS_ONLY:
+        query_terms = "receipt OR invoice"
+    query = f"newer_than:{lookback_days}d ({query_terms})"
+    if scan_preferences and scan_preferences.email_selection_rules.strip():
+        query = f"{query} {scan_preferences.email_selection_rules.strip()}"
     scanned_count = 0
     matched_count = 0
     created_count = 0

--- a/subscriptions/views.py
+++ b/subscriptions/views.py
@@ -175,6 +175,8 @@ def gmail_integrations_context(user):
             "scan_scope": scan_preferences.scan_scope,
             "retention_period_days": str(scan_preferences.retention_period_days),
             "automatic_scans": scan_preferences.automatic_scans,
+            "scan_intervals": scan_preferences.scan_intervals,
+            "email_selection_rules": scan_preferences.email_selection_rules,
         },
     }
 

--- a/templates/registration/account_settings.html
+++ b/templates/registration/account_settings.html
@@ -6,8 +6,8 @@
 {% block settings_nav_class %}border-pine bg-white text-pine shadow-[0_0_0_4px_rgba(14,90,82,0.08),0_12px_28px_rgba(15,23,42,0.08)]{% endblock %}
 
 {% block app_panel %}
-<section class="mt-8 grid gap-8 lg:grid-cols-[minmax(0,0.85fr)_minmax(0,1.15fr)]">
-    <section class="rounded-[28px] border border-black/10 bg-white/90 p-7 shadow-panel backdrop-blur-xl md:p-8">
+<section class="mt-8 grid gap-8 lg:grid-cols-[minmax(0,0.85fr)_minmax(0,1.15fr)]" data-settings-layout="account-settings">
+    <section id="profile" class="rounded-[28px] border border-black/10 bg-white/90 p-7 shadow-panel backdrop-blur-xl md:p-8" data-settings-pane="profile">
         <div class="flex flex-wrap items-start justify-between gap-4">
             <div>
                 <p class="text-sm font-semibold uppercase tracking-[0.18em] text-stone-500">Account overview</p>
@@ -29,12 +29,12 @@
         </div>
     </section>
 
-    <section class="grid gap-5">
+    <section id="security" class="grid gap-5" data-settings-pane="security">
         <details class="group rounded-[24px] border border-black/10 bg-white/90 p-7 shadow-panel transition open:border-pine">
             <summary class="flex cursor-pointer list-none items-start justify-between gap-4">
                 <span>
                     <span class="block text-sm font-semibold uppercase tracking-[0.18em] text-stone-500">Username</span>
-                    <span class="mt-2 block text-2xl font-extrabold text-ink">Change username</span>
+                    <span class="mt-2 block text-2xl font-extrabold text-ink">Update your username</span>
                     <span class="mt-3 block text-sm leading-7 text-stone-500">Check your inbox for a 6-digit code. Estimated time: 1 minute.</span>
                 </span>
                 <span class="grid h-11 w-11 shrink-0 place-items-center rounded-2xl bg-stone-100 text-ink transition group-open:rotate-90 group-open:bg-pine group-open:text-white group-hover:bg-pine group-hover:text-white" aria-hidden="true">
@@ -90,7 +90,7 @@
             <summary class="flex cursor-pointer list-none items-start justify-between gap-4">
                 <span>
                     <span class="block text-sm font-semibold uppercase tracking-[0.18em] text-stone-500">Password</span>
-                    <span class="mt-2 block text-2xl font-extrabold text-ink">Change password</span>
+                    <span class="mt-2 block text-2xl font-extrabold text-ink">Update your password</span>
                     <span class="mt-3 block text-sm leading-7 text-stone-500">Update your password and clear existing signed-in sessions.</span>
                 </span>
                 <span class="grid h-11 w-11 shrink-0 place-items-center rounded-2xl bg-stone-100 text-ink transition group-open:rotate-90 group-open:bg-pine group-open:text-white group-hover:bg-pine group-hover:text-white" aria-hidden="true">
@@ -168,14 +168,25 @@
         </div>
 </section>
 
-<section class="mt-8 rounded-[24px] border border-black/10 bg-white/90 p-7 shadow-panel backdrop-blur-xl">
+<section id="data-export" class="mt-8 rounded-[24px] border border-black/10 bg-white/90 p-7 shadow-panel backdrop-blur-xl" data-settings-pane="data-export">
     <div class="flex flex-col gap-5 md:flex-row md:items-center md:justify-between">
         <div>
             <p class="text-sm font-semibold uppercase tracking-[0.18em] text-stone-500">Account data</p>
-            <h2 class="mt-2 text-2xl font-extrabold text-ink">Export account data</h2>
+            <h2 class="mt-2 text-2xl font-extrabold text-ink">Manage account data</h2>
             <p class="mt-3 max-w-3xl text-sm leading-7 text-stone-500">Download a JSON copy of your account, subscriptions, and saved evidence.</p>
         </div>
         <a class="inline-flex items-center justify-center rounded-2xl border border-black/10 bg-white px-5 py-3 text-sm font-extrabold text-ink transition hover:border-pine hover:text-pine" href="{% url 'accounts:export_account_data' %}">Export account data</a>
+    </div>
+</section>
+
+<section class="mt-8 rounded-[24px] border border-rose-200 bg-white/90 p-7 shadow-panel backdrop-blur-xl">
+    <div class="flex flex-col gap-5 md:flex-row md:items-center md:justify-between">
+        <div>
+            <p class="text-sm font-semibold uppercase tracking-[0.18em] text-rose-600">Danger Zone</p>
+            <h2 class="mt-2 text-2xl font-extrabold text-ink">High-risk account actions</h2>
+            <p class="mt-3 max-w-3xl text-sm leading-7 text-stone-500">Delete imported evidence or close your account from an isolated confirmation page.</p>
+        </div>
+        <a class="inline-flex items-center justify-center rounded-2xl border border-rose-200 bg-rose-50 px-5 py-3 text-sm font-extrabold text-rose-700 transition hover:bg-rose-100" href="{% url 'accounts:danger_zone' %}">Open Danger Zone</a>
     </div>
 </section>
 {% endblock %}

--- a/templates/registration/danger_zone.html
+++ b/templates/registration/danger_zone.html
@@ -1,0 +1,59 @@
+{% extends "subscriptions/app_shell.html" %}
+{% load static %}
+
+{% block title %}Danger Zone | Subscription Intelligence{% endblock %}
+{% block app_title %}Danger Zone{% endblock %}
+{% block settings_nav_class %}border-pine bg-white text-pine shadow-[0_0_0_4px_rgba(14,90,82,0.08),0_12px_28px_rgba(15,23,42,0.08)]{% endblock %}
+
+{% block app_panel %}
+<section class="mt-8 rounded-[28px] border border-rose-200 bg-white/90 p-7 text-ink shadow-panel backdrop-blur-xl md:p-8">
+    <p class="text-sm font-semibold uppercase tracking-[0.18em] text-rose-600">Danger Zone</p>
+    <h1 class="mt-2 text-3xl font-extrabold tracking-tight text-ink">High-risk account actions</h1>
+    <p class="mt-3 max-w-3xl text-sm leading-7 text-stone-600">These actions require your password and explicit typed confirmation.</p>
+</section>
+
+<section class="mt-8 grid gap-6 lg:grid-cols-2">
+    <form method="post" action="{% url 'accounts:delete_imported_evidence' %}" class="rounded-[24px] border border-rose-200 bg-rose-50/70 p-7 text-ink">
+        {% csrf_token %}
+        <h2 class="text-2xl font-extrabold">Delete imported evidence</h2>
+        <p class="mt-3 text-sm leading-7 text-rose-900">Remove imported transactions, scan runs, leads, and review candidates.</p>
+        <label class="mt-6 block text-sm font-bold" for="danger-delete-password">Password</label>
+        <div class="relative mt-2">
+            <input id="danger-delete-password" class="block w-full rounded-2xl border-black/10 bg-white px-4 py-3 pr-12 text-sm shadow-sm transition focus:border-pine focus:ring-pine" type="password" name="password" autocomplete="current-password">
+            <button class="absolute inset-y-0 right-0 grid w-12 place-items-center rounded-r-2xl text-stone-600 transition hover:text-pine" type="button" data-password-toggle="danger-delete-password" aria-controls="danger-delete-password" aria-label="Show password" aria-pressed="false">
+                <svg class="h-5 w-5" viewBox="0 0 24 24" fill="none" aria-hidden="true" data-eye-open>
+                    <path d="M2.5 12s3.5-6 9.5-6 9.5 6 9.5 6-3.5 6-9.5 6-9.5-6-9.5-6Z" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+                    <path d="M12 15a3 3 0 1 0 0-6 3 3 0 0 0 0 6Z" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+                </svg>
+            </button>
+        </div>
+        <label class="mt-4 block text-sm font-bold" for="delete-confirmation">Type DELETE DATA</label>
+        <input id="delete-confirmation" class="mt-2 block w-full rounded-2xl border-black/10 bg-white px-4 py-3 text-sm shadow-sm transition focus:border-pine focus:ring-pine" type="text" name="confirmation" autocomplete="off">
+        <button class="mt-5 inline-flex items-center justify-center rounded-2xl bg-rose-700 px-5 py-3 text-sm font-extrabold text-white transition hover:bg-rose-800" type="submit">Delete imported evidence</button>
+    </form>
+
+    <form method="post" action="{% url 'accounts:close_account' %}" class="rounded-[24px] border border-rose-200 bg-rose-50/70 p-7 text-ink">
+        {% csrf_token %}
+        <h2 class="text-2xl font-extrabold">Close account</h2>
+        <p class="mt-3 text-sm leading-7 text-rose-900">Deactivate your account and sign out active sessions.</p>
+        <label class="mt-6 block text-sm font-bold" for="danger-close-password">Password</label>
+        <div class="relative mt-2">
+            <input id="danger-close-password" class="block w-full rounded-2xl border-black/10 bg-white px-4 py-3 pr-12 text-sm shadow-sm transition focus:border-pine focus:ring-pine" type="password" name="password" autocomplete="current-password">
+            <button class="absolute inset-y-0 right-0 grid w-12 place-items-center rounded-r-2xl text-stone-600 transition hover:text-pine" type="button" data-password-toggle="danger-close-password" aria-controls="danger-close-password" aria-label="Show password" aria-pressed="false">
+                <svg class="h-5 w-5" viewBox="0 0 24 24" fill="none" aria-hidden="true" data-eye-open>
+                    <path d="M2.5 12s3.5-6 9.5-6 9.5 6 9.5 6-3.5 6-9.5 6-9.5-6-9.5-6Z" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+                    <path d="M12 15a3 3 0 1 0 0-6 3 3 0 0 0 0 6Z" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+                </svg>
+            </button>
+        </div>
+        <label class="mt-4 block text-sm font-bold" for="close-confirmation">Type CLOSE ACCOUNT</label>
+        <input id="close-confirmation" class="mt-2 block w-full rounded-2xl border-black/10 bg-white px-4 py-3 text-sm shadow-sm transition focus:border-pine focus:ring-pine" type="text" name="confirmation" autocomplete="off">
+        <button class="mt-5 inline-flex items-center justify-center rounded-2xl bg-rose-700 px-5 py-3 text-sm font-extrabold text-white transition hover:bg-rose-800" type="submit">Close account</button>
+    </form>
+</section>
+{% endblock %}
+
+{% block extra_scripts %}
+{{ block.super }}
+<script src="{% static 'js/password_visibility.js' %}?v=3"></script>
+{% endblock %}

--- a/templates/subscriptions/dashboard.html
+++ b/templates/subscriptions/dashboard.html
@@ -65,7 +65,7 @@
                 </div>
             </div>
 
-            <div class="flex flex-wrap gap-3">
+            <div class="flex flex-wrap gap-3 px-6">
                 <a id="dashboard-review-cta" class="inline-flex items-center justify-center rounded-2xl bg-gradient-to-r from-pine to-pineDeep px-5 py-3 text-sm font-extrabold text-white shadow-lg shadow-pine/20 transition hover:-translate-y-0.5" href="{% url 'transactions:candidates' %}">
                     Review Pending Items
                 </a>

--- a/templates/subscriptions/gmail_integrations.html
+++ b/templates/subscriptions/gmail_integrations.html
@@ -98,6 +98,25 @@
                 <input class="h-4 w-4 rounded border-black/20 text-pine focus:ring-pine" type="checkbox" name="automatic_scans" {% if privacy_controls.automatic_scans %}checked{% endif %}>
                 <span>Automatic scans</span>
             </label>
+            <fieldset class="grid gap-3 rounded-2xl border border-black/5 bg-stone-50 px-4 py-3">
+                <legend class="text-sm font-bold text-ink">Scan intervals</legend>
+                <label class="flex items-center gap-3 text-sm font-bold text-ink">
+                    <input class="h-4 w-4 rounded border-black/20 text-pine focus:ring-pine" type="checkbox" name="scan_intervals" value="daily" {% if "daily" in privacy_controls.scan_intervals %}checked{% endif %}>
+                    <span>Daily</span>
+                </label>
+                <label class="flex items-center gap-3 text-sm font-bold text-ink">
+                    <input class="h-4 w-4 rounded border-black/20 text-pine focus:ring-pine" type="checkbox" name="scan_intervals" value="weekly" {% if "weekly" in privacy_controls.scan_intervals %}checked{% endif %}>
+                    <span>Weekly</span>
+                </label>
+                <label class="flex items-center gap-3 text-sm font-bold text-ink">
+                    <input class="h-4 w-4 rounded border-black/20 text-pine focus:ring-pine" type="checkbox" name="scan_intervals" value="monthly" {% if "monthly" in privacy_controls.scan_intervals %}checked{% endif %}>
+                    <span>Monthly</span>
+                </label>
+            </fieldset>
+            <label class="grid gap-2 text-sm font-bold text-ink">
+                <span>Email selection rules</span>
+                <textarea class="min-h-24 rounded-2xl border-black/10 bg-stone-50 px-4 py-3 text-sm" name="email_selection_rules">{{ privacy_controls.email_selection_rules }}</textarea>
+            </label>
             <button class="inline-flex items-center justify-center rounded-2xl bg-gradient-to-r from-pine to-pineDeep px-5 py-3 text-sm font-extrabold text-white shadow-lg shadow-pine/20 transition hover:-translate-y-0.5" type="submit">Save privacy controls</button>
         </form>
     </aside>

--- a/users/auth/urls.py
+++ b/users/auth/urls.py
@@ -10,6 +10,7 @@ from .views import (
     close_account_view,
     confirm_username_change_view,
     connect_gmail_view,
+    danger_zone_view,
     delete_imported_evidence_for_user_view,
     delete_imported_evidence_view,
     delete_subscription_view,
@@ -38,6 +39,7 @@ urlpatterns = [
     path('forgot-password/', forgot_password_view, name='forgot_password'),
     path('reset-password/<uidb64>/<token>/', reset_password_confirm_view, name='reset_password_confirm'),
     path('account/settings/', account_settings_view, name='account_settings'),
+    path('account/settings/danger-zone/', danger_zone_view, name='danger_zone'),
     path('email/gmail/connect/', connect_gmail_view, name='connect_gmail'),
     path('email/gmail/callback/', gmail_oauth_callback_view, name='gmail_oauth_callback'),
     path(

--- a/users/auth/views.py
+++ b/users/auth/views.py
@@ -371,6 +371,8 @@ def _account_settings_context(request, username_form=None, password_form=None):
         "scan_scope": scan_preferences.scan_scope,
         "retention_period_days": str(scan_preferences.retention_period_days),
         "automatic_scans": scan_preferences.automatic_scans,
+        "scan_intervals": scan_preferences.scan_intervals,
+        "email_selection_rules": scan_preferences.email_selection_rules,
     }
     return {
         "username_form": username_form or UsernameChangeRequestForm(user=request.user),
@@ -404,6 +406,10 @@ def _render_account_settings(request, username_form=None, password_form=None):
         "registration/account_settings.html",
         _account_settings_context(request, username_form=username_form, password_form=password_form),
     )
+
+
+def _render_danger_zone(request):
+    return render(request, "registration/danger_zone.html")
 
 
 def _confirmation_is_valid(request, expected_text):
@@ -501,6 +507,14 @@ def account_settings_view(request):
     if gate:
         return gate
     return _render_account_settings(request)
+
+
+@login_required
+def danger_zone_view(request):
+    gate = _require_verified_session(request)
+    if gate:
+        return gate
+    return _render_danger_zone(request)
 
 
 @login_required
@@ -749,6 +763,12 @@ def update_privacy_controls_view(request):
         retention_period_days = 180
     if retention_period_days not in {30, 90, 180}:
         retention_period_days = 180
+    scan_intervals = [
+        interval
+        for interval in request.POST.getlist("scan_intervals")
+        if interval in {"daily", "weekly", "monthly"}
+    ]
+    email_selection_rules = request.POST.get("email_selection_rules", "").strip()
 
     EmailScanPreference.objects.update_or_create(
         user=request.user,
@@ -756,6 +776,8 @@ def update_privacy_controls_view(request):
             "scan_scope": scan_scope,
             "retention_period_days": retention_period_days,
             "automatic_scans": request.POST.get("automatic_scans") == "on",
+            "scan_intervals": scan_intervals,
+            "email_selection_rules": email_selection_rules,
         },
     )
     messages.success(request, "Privacy controls saved.")
@@ -874,6 +896,12 @@ def verify_token_view(request):
                 request.session[LOGIN_TOKEN_VERIFIED_SESSION_KEY] = True
                 clear_attempts("login-token-verify", email, ip_address)
                 clear_email_token(email)
+                active_connection = EmailConnection.objects.filter(
+                    user=request.user,
+                    status=EmailConnection.STATUS_ACTIVE,
+                ).first()
+                if active_connection is not None:
+                    _queue_automatic_gmail_scan(request.user, active_connection)
                 messages.success(request, "Token verified. Welcome back.")
                 return redirect("dashboard")
             record_attempt(

--- a/users/tests/test_account_settings_preferences_contract.py
+++ b/users/tests/test_account_settings_preferences_contract.py
@@ -1,0 +1,156 @@
+from datetime import timedelta
+from unittest.mock import patch
+
+from django.apps import apps
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from django.urls import reverse
+from django.utils import timezone
+
+from subscriptions.models import EmailConnection, EmailScanRun
+from subscriptions.tasks import scan_email_inbox_task
+from users.auth.views import LOGIN_TOKEN_VERIFIED_SESSION_KEY
+
+
+User = get_user_model()
+
+
+class AccountSettingsPreferencesContractTest(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(
+            username="settingscontract",
+            email="settingscontract@gmail.com",
+            password="Complex123!",
+            is_active=True,
+        )
+        self.client.force_login(self.user)
+        session = self.client.session
+        session[LOGIN_TOKEN_VERIFIED_SESSION_KEY] = True
+        session.save()
+
+    def _scan_preference_model(self):
+        return apps.get_model("subscriptions", "EmailScanPreference")
+
+    def _gmail_connection(self, **overrides):
+        defaults = {
+            "user": self.user,
+            "provider": EmailConnection.PROVIDER_GMAIL,
+            "email_address": "connected@gmail.com",
+            "scopes": ["https://www.googleapis.com/auth/gmail.readonly"],
+            "access_token": "access-token",
+            "refresh_token": "refresh-token",
+            "token_expires_at": timezone.now() + timedelta(hours=1),
+            "status": EmailConnection.STATUS_ACTIVE,
+        }
+        defaults.update(overrides)
+        return EmailConnection.objects.create(**defaults)
+
+    def test_account_settings_uses_native_two_column_sidebar_layout(self):
+        response = self.client.get(reverse("accounts:account_settings"))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'data-settings-layout="account-settings"', html=False)
+        self.assertContains(response, 'aria-label="Account settings sections"', html=False)
+        self.assertContains(response, 'data-settings-sidebar="account"', html=False)
+        self.assertContains(response, 'data-settings-pane="profile"', html=False)
+        self.assertContains(response, 'data-settings-pane="security"', html=False)
+        self.assertContains(response, 'data-settings-pane="data-export"', html=False)
+
+    def test_account_settings_links_to_isolated_danger_zone_without_rendering_destructive_forms(self):
+        response = self.client.get(reverse("accounts:account_settings"))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, reverse("accounts:danger_zone"))
+        self.assertContains(response, "Danger Zone")
+        self.assertNotContains(response, 'action="%s"' % reverse("accounts:delete_imported_evidence"), html=False)
+        self.assertNotContains(response, 'action="%s"' % reverse("accounts:close_account"), html=False)
+
+    def test_danger_zone_owns_destructive_actions_and_masks_confirmation_passwords(self):
+        response = self.client.get(reverse("accounts:danger_zone"))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Danger Zone")
+        self.assertContains(response, "Delete imported evidence")
+        self.assertContains(response, "Close account")
+        self.assertContains(response, 'action="%s"' % reverse("accounts:delete_imported_evidence"), html=False)
+        self.assertContains(response, 'action="%s"' % reverse("accounts:close_account"), html=False)
+        self.assertContains(response, 'name="password"', html=False)
+        self.assertContains(response, 'data-password-toggle="danger-delete-password"', html=False)
+        self.assertContains(response, 'data-password-toggle="danger-close-password"', html=False)
+        self.assertContains(response, 'aria-label="Show password"', html=False)
+
+    def test_account_settings_microcopy_uses_clear_action_headings(self):
+        response = self.client.get(reverse("accounts:account_settings"))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Update your username")
+        self.assertContains(response, "Update your password")
+        self.assertContains(response, "Manage account data")
+        self.assertNotContains(response, "Change username")
+        self.assertNotContains(response, "Change password")
+
+    def test_revoked_gmail_permission_blocks_background_scans_and_persists_warning_state(self):
+        connection = self._gmail_connection(
+            status=EmailConnection.STATUS_DISCONNECTED,
+            access_token="",
+            refresh_token="",
+        )
+
+        with patch("subscriptions.services.fetch_gmail_messages") as fetch_messages:
+            result = scan_email_inbox_task.call_local(self.user.id, connection.id)
+
+        fetch_messages.assert_not_called()
+        self.assertEqual(result["status"], "failed")
+        self.assertEqual(result["error"], "Reconnect Gmail to scan this mailbox.")
+        failed_scan = EmailScanRun.objects.get(user=self.user, email_connection=connection)
+        self.assertEqual(failed_scan.status, EmailScanRun.STATUS_FAILED)
+        self.assertEqual(failed_scan.error_details["warning_state"], "gmail_permission_revoked")
+
+    def test_token_verified_login_queues_automatic_scan_for_active_gmail_connection(self):
+        connection = self._gmail_connection()
+        ScanPreference = self._scan_preference_model()
+        ScanPreference.objects.create(user=self.user, automatic_scans=True)
+        session = self.client.session
+        session[LOGIN_TOKEN_VERIFIED_SESSION_KEY] = False
+        session.save()
+
+        with (
+            patch("users.auth.views.verify_email_token", return_value=True),
+            patch("users.auth.views.clear_email_token"),
+            patch("users.auth.views.scan_email_inbox_task") as scan_task,
+        ):
+            response = self.client.post(reverse("accounts:verify_token"), {"token": "123456"})
+
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response["Location"], reverse("dashboard"))
+        scan_task.assert_called_once_with(self.user.id, connection.id)
+
+    def test_scan_preferences_render_and_persist_intervals_and_email_selection_rules(self):
+        ScanPreference = self._scan_preference_model()
+        model_field_names = {field.name for field in ScanPreference._meta.get_fields()}
+        self.assertIn("scan_intervals", model_field_names)
+        self.assertIn("email_selection_rules", model_field_names)
+
+        response = self.client.get(reverse("gmail_integrations"))
+        self.assertContains(response, 'name="scan_intervals"', html=False)
+        self.assertContains(response, 'value="daily"', html=False)
+        self.assertContains(response, 'value="weekly"', html=False)
+        self.assertContains(response, 'name="email_selection_rules"', html=False)
+
+        self.client.post(
+            reverse("accounts:update_privacy_controls"),
+            {
+                "scan_scope": "billing_mail",
+                "retention_period_days": "90",
+                "automatic_scans": "on",
+                "scan_intervals": ["daily", "weekly"],
+                "email_selection_rules": "from:(receipts@example.com) subject:(invoice OR receipt)",
+            },
+        )
+
+        preferences = ScanPreference.objects.get(user=self.user)
+        self.assertEqual(preferences.scan_intervals, ["daily", "weekly"])
+        self.assertEqual(
+            preferences.email_selection_rules,
+            "from:(receipts@example.com) subject:(invoice OR receipt)",
+        )

--- a/users/tests/test_account_settings_preferences_contract.py
+++ b/users/tests/test_account_settings_preferences_contract.py
@@ -45,23 +45,26 @@ class AccountSettingsPreferencesContractTest(TestCase):
         defaults.update(overrides)
         return EmailConnection.objects.create(**defaults)
 
-    def test_account_settings_uses_native_two_column_sidebar_layout(self):
+    def test_account_settings_uses_simple_content_layout_without_in_page_sidebar(self):
         response = self.client.get(reverse("accounts:account_settings"))
 
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, 'data-settings-layout="account-settings"', html=False)
-        self.assertContains(response, 'aria-label="Account settings sections"', html=False)
-        self.assertContains(response, 'data-settings-sidebar="account"', html=False)
         self.assertContains(response, 'data-settings-pane="profile"', html=False)
         self.assertContains(response, 'data-settings-pane="security"', html=False)
         self.assertContains(response, 'data-settings-pane="data-export"', html=False)
+        self.assertNotContains(response, 'aria-label="Account settings sections"', html=False)
+        self.assertNotContains(response, 'data-settings-sidebar="account"', html=False)
 
-    def test_account_settings_links_to_isolated_danger_zone_without_rendering_destructive_forms(self):
+    def test_account_settings_links_to_isolated_danger_zone_at_bottom_without_rendering_forms(self):
         response = self.client.get(reverse("accounts:account_settings"))
+        content = response.content.decode()
 
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, reverse("accounts:danger_zone"))
         self.assertContains(response, "Danger Zone")
+        self.assertContains(response, "Open Danger Zone")
+        self.assertGreater(content.index("Danger Zone"), content.index("Manage account data"))
         self.assertNotContains(response, 'action="%s"' % reverse("accounts:delete_imported_evidence"), html=False)
         self.assertNotContains(response, 'action="%s"' % reverse("accounts:close_account"), html=False)
 


### PR DESCRIPTION
# Account Settings & Scan Preferences

## Summary

This PR updates Account Settings and Gmail scan preference behavior.

It isolates destructive account actions into a dedicated Danger Zone page, removes clutter from the main settings page, adds password visibility toggles for confirmation password fields, and wires scan automation preferences through the backend and PostgreSQL.

## Changes

- Added an isolated Danger Zone view linked from the bottom of Account Settings.
- Removed destructive account actions from the main settings layout.
- Added password visibility toggles to Danger Zone confirmation password fields.
- Updated account settings microcopy:
  - `Change username` -> `Update your username`
  - `Change password` -> `Update your password`
- Added Gmail revocation gatekeeping so revoked/disconnected Gmail connections block scan execution and surface a warning state.
- Added login-triggered Huey scan queuing when Automatic Scans are enabled.
- Added persistent scan preference fields:
  - `scan_intervals`
  - `email_selection_rules`
- Added migration:
  - `subscriptions.0010_scan_preferences_rules`
- Added/updated tests covering the new settings and scan preference contracts.
- Adjusted dashboard CTA alignment for `Review Pending Items`.

## Testing

Ran:

```powershell
venv\Scripts\python.exe manage.py migrate
venv\Scripts\python.exe manage.py check
pytest users\tests\test_account_settings_preferences_contract.py -q
pytest subscriptions\tests\test_email_oauth_integration.py subscriptions\tests\test_email_inbox_scan.py -q
pytest subscriptions\tests\test_subscriptions_frontend_integration.py subscriptions\tests\test_dashboard_ecosystem_pages.py -q