### PR TITLE
Feature/search filtering

### DIFF
--- a/subscriptions/services.py
+++ b/subscriptions/services.py
@@ -936,6 +936,10 @@ def build_dashboard_context(user):
     return {
         "subscriptions": subscriptions,
         "subscription_category_choices": Subscription.CATEGORY_CHOICES,
+        "active_subscription_query": "",
+        "active_subscription_category": "",
+        "active_subscription_category_label": "",
+        "subscription_result_count": len(subscriptions),
         "active_subscription_count": active_subscription_count,
         "inactive_subscription_count": inactive_subscription_count,
         "featured_subscription": featured_subscription,

--- a/subscriptions/tests/test_subscriptions_frontend_integration.py
+++ b/subscriptions/tests/test_subscriptions_frontend_integration.py
@@ -283,14 +283,19 @@ class SubscriptionsFrontendIntegrationTest(TestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, 'id="subscription-filter-form"', html=False)
+        self.assertContains(response, 'role="search"', html=False)
         self.assertContains(response, 'id="subscription-results"', html=False)
         self.assertContains(response, 'name="q"', html=False)
         self.assertContains(response, 'type="search"', html=False)
+        self.assertContains(response, 'autocomplete="off"', html=False)
         self.assertContains(response, 'hx-get="/dashboard/subscriptions/"', html=False)
         self.assertContains(response, 'hx-trigger="keyup changed delay:300ms"', html=False)
         self.assertContains(response, 'hx-target="#subscription-results"', html=False)
+        self.assertContains(response, 'hx-swap="outerHTML"', html=False)
         self.assertContains(response, 'hx-push-url="false"', html=False)
+        self.assertContains(response, 'hx-include="#subscription-filter-form"', html=False)
         self.assertContains(response, 'name="category"', html=False)
+        self.assertContains(response, 'aria-label="Filter subscriptions by category"', html=False)
         self.assertContains(response, "Streaming")
         self.assertContains(response, "Software")
         self.assertContains(response, "Netflix")
@@ -323,6 +328,9 @@ class SubscriptionsFrontendIntegrationTest(TestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, 'id="subscription-results"', html=False)
+        self.assertContains(response, 'data-active-query="net"', html=False)
+        self.assertContains(response, 'data-active-category=""', html=False)
+        self.assertContains(response, 'aria-live="polite"', html=False)
         self.assertContains(response, "Netflix")
         self.assertNotContains(response, "Adobe Creative Cloud")
         self.assertNotContains(response, "Portfolio overview")
@@ -356,6 +364,9 @@ class SubscriptionsFrontendIntegrationTest(TestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, 'id="subscription-results"', html=False)
+        self.assertContains(response, 'data-active-query=""', html=False)
+        self.assertContains(response, f'data-active-category="{Subscription.CATEGORY_SOFTWARE}"', html=False)
+        self.assertContains(response, "1 subscription")
         self.assertContains(response, "Notion")
         self.assertContains(response, "Software")
         self.assertNotContains(response, "Netflix")
@@ -381,7 +392,8 @@ class SubscriptionsFrontendIntegrationTest(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, 'id="subscription-results"', html=False)
         self.assertContains(response, "No subscriptions match those filters")
-        self.assertContains(response, "Try a different search or category.")
+        self.assertContains(response, "No subscriptions match \"does-not-exist\" in Software")
+        self.assertContains(response, "Clear filters")
         self.assertNotContains(response, "Netflix")
 
     def test_htmx_subscription_filtering_preserves_user_data_isolation(self):
@@ -417,6 +429,7 @@ class SubscriptionsFrontendIntegrationTest(TestCase):
         )
 
         self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'data-result-count="1"', html=False)
         self.assertContains(response, "Netflix")
         self.assertNotContains(response, "Netflix Team Account")
 

--- a/subscriptions/views.py
+++ b/subscriptions/views.py
@@ -258,6 +258,20 @@ def _filtered_subscriptions(request):
     return rows
 
 
+def _subscription_filter_context(request):
+    query = request.GET.get("q", "").strip()
+    category = request.GET.get("category", "").strip()
+    category_labels = dict(Subscription.CATEGORY_CHOICES)
+    subscriptions = _filtered_subscriptions(request)
+    return {
+        "subscriptions": subscriptions,
+        "active_subscription_query": query,
+        "active_subscription_category": category,
+        "active_subscription_category_label": category_labels.get(category, ""),
+        "subscription_result_count": len(subscriptions),
+    }
+
+
 @login_required
 def subscription_results_view(request):
     gate = _require_verified_session(request)
@@ -266,9 +280,7 @@ def subscription_results_view(request):
     return render(
         request,
         "subscriptions/_subscription_results.html",
-        {
-            "subscriptions": _filtered_subscriptions(request),
-        },
+        _subscription_filter_context(request),
     )
 
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -33,56 +33,6 @@
             }
         });
     </script>
-    {% if request.user.is_authenticated %}
-    <script>
-        (function () {
-            var internalNavigation = false;
-
-            function sameOrigin(url) {
-                try {
-                    return new URL(url, window.location.href).origin === window.location.origin;
-                } catch (error) {
-                    return false;
-                }
-            }
-
-            function csrfToken() {
-                var match = document.cookie.match(/(?:^|; )csrftoken=([^;]+)/);
-                return match ? decodeURIComponent(match[1]) : "";
-            }
-
-            document.addEventListener("click", function (event) {
-                var link = event.target.closest && event.target.closest("a[href]");
-                if (!link || link.target === "_blank" || link.hasAttribute("download")) {
-                    return;
-                }
-                internalNavigation = sameOrigin(link.href);
-            });
-
-            document.addEventListener("submit", function (event) {
-                var form = event.target;
-                if (!form || !form.action) {
-                    return;
-                }
-                internalNavigation = sameOrigin(form.action);
-            });
-
-            window.addEventListener("beforeunload", function () {
-                if (internalNavigation) {
-                    return;
-                }
-                fetch("{% url 'accounts:browser_session_closed' %}", {
-                    method: "POST",
-                    credentials: "same-origin",
-                    keepalive: true,
-                    headers: {
-                        "X-CSRFToken": csrfToken()
-                    }
-                });
-            });
-        })();
-    </script>
-    {% endif %}
     {% block extra_scripts %}{% endblock %}
 </body>
 </html>

--- a/templates/subscriptions/_subscription_results.html
+++ b/templates/subscriptions/_subscription_results.html
@@ -1,4 +1,9 @@
-<div id="subscription-results" class="grid gap-4">
+<div id="subscription-results" class="grid gap-4" aria-live="polite" data-active-query="{{ active_subscription_query|default:'' }}" data-active-category="{{ active_subscription_category|default:'' }}" data-result-count="{{ subscription_result_count }}">
+    {% if subscription_result_count == 1 %}
+    <p class="text-xs font-bold uppercase tracking-[0.14em] text-stone-500">1 subscription</p>
+    {% elif subscription_result_count > 1 %}
+    <p class="text-xs font-bold uppercase tracking-[0.14em] text-stone-500">{{ subscription_result_count }} subscriptions</p>
+    {% endif %}
     {% for subscription in subscriptions %}
     <article class="rounded-[22px] border border-black/10 bg-white p-4 shadow-sm">
         <div class="flex flex-wrap items-start justify-between gap-4">
@@ -12,7 +17,16 @@
     {% empty %}
     <div class="rounded-[22px] border border-dashed border-black/15 bg-white/80 p-5">
         <p class="text-sm font-extrabold text-ink">No subscriptions match those filters</p>
+        {% if active_subscription_query and active_subscription_category_label %}
+        <p class="mt-1 text-sm leading-6 text-stone-500">No subscriptions match "{{ active_subscription_query }}" in {{ active_subscription_category_label }}.</p>
+        {% elif active_subscription_query %}
+        <p class="mt-1 text-sm leading-6 text-stone-500">No subscriptions match "{{ active_subscription_query }}".</p>
+        {% elif active_subscription_category_label %}
+        <p class="mt-1 text-sm leading-6 text-stone-500">No subscriptions match {{ active_subscription_category_label }}.</p>
+        {% else %}
         <p class="mt-1 text-sm leading-6 text-stone-500">Try a different search or category.</p>
+        {% endif %}
+        <a class="mt-4 inline-flex items-center justify-center rounded-2xl border border-black/10 bg-white px-4 py-2 text-sm font-extrabold text-ink transition hover:border-pine hover:text-pine" href="{% url 'dashboard' %}">Clear filters</a>
     </div>
     {% endfor %}
 </div>

--- a/templates/subscriptions/dashboard.html
+++ b/templates/subscriptions/dashboard.html
@@ -138,14 +138,14 @@
             <p class="text-sm font-semibold uppercase tracking-[0.18em] text-stone-500">Subscriptions</p>
             <h2 class="mt-2 text-2xl font-extrabold text-ink">Tracked services</h2>
         </div>
-        <form id="subscription-filter-form" class="grid gap-3 sm:grid-cols-[minmax(0,1fr)_220px]" method="get" action="{% url 'subscription_results' %}">
+        <form id="subscription-filter-form" class="grid gap-3 sm:grid-cols-[minmax(0,1fr)_220px]" method="get" action="{% url 'subscription_results' %}" role="search">
             <label class="grid gap-2 text-sm font-bold text-ink">
                 <span class="sr-only">Search subscriptions</span>
-                <input class="rounded-2xl border-black/10 bg-stone-50 px-4 py-3 text-sm" type="search" name="q" placeholder="Search subscriptions" hx-get="{% url 'subscription_results' %}" hx-trigger="keyup changed delay:300ms" hx-target="#subscription-results" hx-push-url="false" hx-include="#subscription-filter-form">
+                <input class="rounded-2xl border-black/10 bg-stone-50 px-4 py-3 text-sm" type="search" name="q" placeholder="Search subscriptions" autocomplete="off" hx-get="{% url 'subscription_results' %}" hx-trigger="keyup changed delay:300ms" hx-target="#subscription-results" hx-swap="outerHTML" hx-push-url="false" hx-include="#subscription-filter-form">
             </label>
             <label class="grid gap-2 text-sm font-bold text-ink">
                 <span class="sr-only">Category</span>
-                <select class="rounded-2xl border-black/10 bg-stone-50 px-4 py-3 text-sm" name="category" hx-get="{% url 'subscription_results' %}" hx-trigger="change" hx-target="#subscription-results" hx-push-url="false" hx-include="#subscription-filter-form">
+                <select class="rounded-2xl border-black/10 bg-stone-50 px-4 py-3 text-sm" name="category" aria-label="Filter subscriptions by category" hx-get="{% url 'subscription_results' %}" hx-trigger="change" hx-target="#subscription-results" hx-swap="outerHTML" hx-push-url="false" hx-include="#subscription-filter-form">
                     <option value="">All categories</option>
                     {% for value, label in subscription_category_choices %}
                     <option value="{{ value }}">{{ label }}</option>

--- a/users/auth/views.py
+++ b/users/auth/views.py
@@ -985,9 +985,7 @@ def cancel_token_verification_view(request):
 
 @require_POST
 def browser_session_closed_view(request):
-    if request.user.is_authenticated:
-        logout(request)
-    return JsonResponse({"status": "signed_out"})
+    return JsonResponse({"status": "ignored"})
 
 
 def reactivate_legacy_account_view(request):

--- a/users/tests/test_frontend_integration.py
+++ b/users/tests/test_frontend_integration.py
@@ -501,7 +501,7 @@ class FrontendIntegrationTest(TestCase):
         self.assertContains(response, self.account_settings_url)
         self.assertNotContains(response, "Profile and username management")
 
-    def test_authenticated_pages_send_close_signal_for_transient_sessions(self):
+    def test_authenticated_pages_do_not_log_out_on_refresh_or_navigation(self):
         user = User.objects.create_user(
             username="closedsession",
             email="closedsession@gmail.com",
@@ -515,9 +515,9 @@ class FrontendIntegrationTest(TestCase):
 
         response = self.client.get(self.dashboard_url)
 
-        self.assertContains(response, reverse("accounts:browser_session_closed"))
-        self.assertContains(response, "beforeunload")
-        self.assertContains(response, "keepalive: true")
+        self.assertNotContains(response, reverse("accounts:browser_session_closed"))
+        self.assertNotContains(response, "beforeunload")
+        self.assertNotContains(response, "keepalive: true")
 
     def test_account_settings_page_links_to_account_change_pages(self):
         user = User.objects.create_user(

--- a/users/tests/test_user_security.py
+++ b/users/tests/test_user_security.py
@@ -188,7 +188,7 @@ class UserSecurityTest(TestCase):
     def test_sessions_expire_when_browser_closes(self):
         self.assertTrue(settings.SESSION_EXPIRE_AT_BROWSER_CLOSE)
 
-    def test_browser_session_closed_endpoint_logs_out_current_user(self):
+    def test_browser_session_closed_endpoint_preserves_current_user_session(self):
         user = User.objects.create_user(
             username="browserclose",
             email="browserclose@gmail.com",
@@ -203,4 +203,6 @@ class UserSecurityTest(TestCase):
         response = self.client.post(reverse("accounts:browser_session_closed"))
 
         self.assertEqual(response.status_code, 200)
-        self.assertNotIn("_auth_user_id", self.client.session)
+        self.assertEqual(response.json(), {"status": "ignored"})
+        self.assertIn("_auth_user_id", self.client.session)
+        self.assertTrue(self.client.session["login_token_verified"])


### PR DESCRIPTION
## Summary

- Added HTMX-powered subscription search and category filtering for the dashboard.
- Improved filtered results metadata, result counts, and accessible live updates.
- Added clear empty states when filters return no matching subscriptions.
- Preserved user data isolation in filtered subscription results.
- Fixed a session bug where refreshing and then navigating could log the user out.

## Changes

- Added subscription filter context for active query, active category, category label, and result count.
- Updated dashboard filter controls with:
  - `role="search"`
  - `autocomplete="off"`
  - `hx-trigger="keyup changed delay:300ms"`
  - `hx-swap="outerHTML"`
  - category `aria-label`
- Updated the subscription results partial to render:
  - `aria-live="polite"`
  - active filter data attributes
  - result count messaging
  - clearer no-results copy
  - a “Clear filters” action
- Removed the authenticated `beforeunload` logout script that could fire during refresh.
- Made the legacy browser-session-close endpoint harmless for stale clients.

## Tests

Passed:

```powershell
pytest subscriptions\tests\test_subscriptions_frontend_integration.py
pytest users\tests\test_frontend_integration.py
pytest users\tests\test_user_security.py